### PR TITLE
Fix buffer overflows in ifdnfc-activate.c

### DIFF
--- a/src/ifdnfc-activate.c
+++ b/src/ifdnfc-activate.c
@@ -40,9 +40,9 @@ main(int argc, char *argv[])
   SCARDCONTEXT hContext;
   SCARDHANDLE hCard;
   char *reader;
-  BYTE pbSendBuffer[1 + 1 + sizeof(nfc_connstring)];
+  BYTE pbSendBuffer[1 + sizeof(uint16_t) + sizeof(nfc_connstring)];
   DWORD dwSendLength;
-  BYTE pbRecvBuffer[1];
+  BYTE pbRecvBuffer[1 + sizeof(uint16_t) + sizeof(nfc_connstring)];
   DWORD dwActiveProtocol, dwRecvLength, dwReaders;
   char* mszReaders = NULL;
 


### PR DESCRIPTION
It fixes the following issue with pbRecvBuffer and also expands pbSendBuffer to allow for both bytes of the uint16_t length field.

```
In function 'memcpy',
    inlined from 'main' at ifdnfc-activate.c:189:7:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:29:10:
    warning: '__builtin_memcpy' reading 2 bytes from a region of size 0 [-Wstringop-overread]
   29 |   return __builtin___memcpy_chk (__dest, __src, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   30 |                                  __glibc_objsize0 (__dest));
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
ifdnfc-activate.c: In function 'main':
ifdnfc-activate.c:45:8: note: at offset 1 into source object 'pbRecvBuffer' of size 1
   45 |   BYTE pbRecvBuffer[1];
      |        ^~~~~~~~~~~~
```

The issue was mentioned in https://github.com/nfc-tools/ifdnfc/issues/9#issuecomment-1462738813 a couple of years ago but hasn't been fixed in the repository.